### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
minSdkVersion lowered to 21 to achieve wider compatibility. 

Is there a specific reason why the minSdkVersion was initially set to 26?