### PR TITLE
Fix deprecated UIApplication.openURL(_:) call

### DIFF
--- a/Example/SendIntentExample/ios/App/Share/ShareViewController.swift
+++ b/Example/SendIntentExample/ios/App/Share/ShareViewController.swift
@@ -179,15 +179,15 @@ class ShareViewController: UIViewController {
         }
     }
     
-    @objc func openURL(_ url: URL) -> Bool {
+    @objc func openURL(_ url: URL) {
         var responder: UIResponder? = self
         while responder != nil {
             if let application = responder as? UIApplication {
-                return application.perform(#selector(openURL(_:)), with: url) != nil
+                application.open(url, options: [:], completionHandler: nil)
+                return
             }
             responder = responder?.next
         }
-        return false
     }
     
 }

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ class ShareViewController: UIViewController {
         let fileManager = FileManager.default
         
         let copyFileUrl =
-        fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.SendIntentExample")!
+        fileManager.containerURL(forSecurityApplicationGroupIdentifier: "YOUR_APP_GROUP_ID")!
             .absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
         + "/screenshot_\(index).png"
         do {
@@ -297,15 +297,15 @@ class ShareViewController: UIViewController {
         }
     }
     
-    @objc func openURL(_ url: URL) -> Bool {
+    @objc func openURL(_ url: URL) {
         var responder: UIResponder? = self
         while responder != nil {
             if let application = responder as? UIApplication {
-                return application.perform(#selector(openURL(_:)), with: url) != nil
+                application.open(url, options: [:], completionHandler: nil)
+                return
             }
             responder = responder?.next
         }
-        return false
     }
     
 }


### PR DESCRIPTION
On iOS 18.0.2+ send-intent fails and throws the following error:

```
BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(:) needs to migrate to the non-deprecated UIApplication.open(:options:completionHandler:). Force returning false (NO).
```

This error occurs because `UIApplication.openURL(_:)` is deprecated in favour of the new method using `open(_:options:completionHandler:)`. I've just swapped those out and updated the README accordingly. I hope that helps!