### PR TITLE
Fix OOM crash on large file sharing on iOS

### DIFF
--- a/Example/SendIntentExample/ios/App/Share/ShareViewController.swift
+++ b/Example/SendIntentExample/ios/App/Share/ShareViewController.swift
@@ -52,7 +52,7 @@ class ShareViewController: UIViewController {
         fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.SendIntentExample")!
             .absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)! + url!
             .lastPathComponent.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-        try? Data(contentsOf: url!).write(to: URL(string: copyFileUrl)!)
+        try? fileManager.copyItem(at: url!, to: URL(string: copyFileUrl)!)
         
         return copyFileUrl
     }

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ class ShareViewController: UIViewController {
         fileManager.containerURL(forSecurityApplicationGroupIdentifier: "YOUR_APP_GROUP_ID")!
             .absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)! + url!
             .lastPathComponent.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-        try? Data(contentsOf: url!).write(to: URL(string: copyFileUrl)!)
+        try? fileManager.copyItem(at: url!, to: URL(string: copyFileUrl)!)
         
         return copyFileUrl
     }


### PR DESCRIPTION
Copy files using fileManager APIs instead of storing them in memory