### PR TITLE
docs: improve Capacitor 8 migration guide with explicit import examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,21 @@ Check out my app [mindlib - your personal mind library](https://play.google.com/
 
 ## Migration to Capacitor 8 (new package name/scope)
 
-The plugin is now named `@mindlib-capacitor/send-intent`/`MindlibCapacitorSendIntent` (previously `SendIntent`). If you are migrating from an older version, update your JS/TS import to `@mindlib-capacitor/send-intent` (e.g. in your Android app code), and update the iOS imports to use the new module name in `AppDelegate.swift`.
+The plugin has been renamed. If you are migrating from an older version, you need to update your imports:
+
+**JavaScript/TypeScript:**
+```diff
+- import { SendIntent } from "send-intent";
++ import { SendIntent } from "@mindlib-capacitor/send-intent";
+```
+
+**iOS (AppDelegate.swift):**
+```diff
+- import SendIntent
++ import MindlibCapacitorSendIntent
+```
+
+The exported class name `SendIntent` remains the same, so no changes are needed in your application logic.
 
 ## Projects below Capacitor 3
 


### PR DESCRIPTION
Add clear diff-style examples showing the old vs new import paths:
- JavaScript/TypeScript: send-intent -> @mindlib-capacitor/send-intent
- iOS: SendIntent -> MindlibCapacitorSendIntent